### PR TITLE
Added LightGroup object class, same interface as Light but for groups

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -231,6 +231,91 @@ class Light(object):
         self._alert = value
         self._set('alert', self._alert)
 
+class LightGroup(Light):
+    """ A group of Hue lights, tracked as a group on the bridge 
+    
+    Example:
+
+        >>> b = Bridge()
+        >>> g1 = LightGroup(b, 1)
+        >>> g1.hue = 50000 # all lights in that group turn blue
+        >>> g1.on = False # all will turn off
+
+        >>> g2 = LightGroup(b, 'Kitchen')  # you can also look up groups by name
+        >>>                                # will raise a LookupError if the name doesn't match
+
+    """
+
+    def __init__(self, bridge, group_id):
+        Light.__init__(self, bridge, None)
+        del self.light_id # not relevant for a group
+
+        try:
+            self.group_id = int(group_id)
+        except:
+            name = group_id
+            groups = bridge.get_group()
+            for idnumber, info in groups.items():
+                if info['name'] == name:
+                    self.group_id = int(idnumber)
+                    break
+            else:
+                raise LookupError("Could not find a group by that name.")
+
+
+    # Wrapper functions for get/set through the bridge, adding support for
+    # remembering the transitiontime parameter if the user has set it
+    def _get(self, *args, **kwargs):
+        return self.bridge.get_group(self.group_id, *args, **kwargs)
+    def _set(self, *args, **kwargs):
+        # let's get basic group functionality working first before adding transition time...
+        if self.transitiontime is not None:
+            kwargs['transitiontime'] = self.transitiontime
+            logger.debug("Setting with transitiontime = {0} ds = {1} s".format(self.transitiontime, float(self.transitiontime)/10))
+
+            if args[0] == 'on' and args[1] == False:
+                self._reset_bri_after_on = True
+        return self.bridge.set_group(self.group_id, *args, **kwargs)
+
+    @property
+    def name(self):
+        '''Get or set the name of the light group [string]'''
+        self._name = self._get('name')
+        return self._name
+    @name.setter
+    def name(self, value):
+        old_name = self.name
+        logger.debug("Renaming light group from '{0}' to '{1}'".format(old_name, value))
+        self._set('name', self._name)
+
+
+
+    @property
+    def lights(self):
+        """ Return a list of all lights in this group"""
+        #response = self.bridge.request('GET', '/api/{0}/groups/{1}'.format(self.bridge.username, self.group_id))
+        #return [Light(self.bridge, int(l)) for l in response['lights']]
+        return [Light(self.bridge, int(l)) for l in self._get('lights')]
+    @lights.setter
+    def lights(self, value):
+        """ Change the lights that are in this group"""
+        logger.debug("Setting lights in group {0} to {1}".format(self.group_id, str(value)))
+        self._set('lights', value)
+
+class AllLights(LightGroup):
+    """ All the Hue lights connected to your bridge
+
+    This makes use of the semi-documented feature that
+    "Group 0" of lights appears to be a group automatically
+    consisting of all lights.  This is not returned by
+    listing the groups, but is accessible if you explicitly
+    ask for group 0.
+    """
+    def __init__(self, bridge=None):
+        if bridge==None: bridge=Bridge()
+        LightGroup.__init__(self, bridge,0)
+
+
 class Bridge(object):
     """ Interface to the Hue ZigBee bridge 
     
@@ -471,7 +556,14 @@ class Bridge(object):
 
         logger.debug(result)
         return result
-    
+
+    ##### Groups of lights #####
+    @property
+    def groups(self):
+        """ Access groups as a list """
+        return [LightGroup(self, groupid) for groupid in  self.get_group().keys()]
+
+
     def get_group(self, group_id = None, parameter = None):
         if group_id == None:
             return self.request('GET', '/api/' + self.username + '/groups/')
@@ -482,13 +574,21 @@ class Bridge(object):
         else:
             return self.request('GET', '/api/' + self.username + '/groups/'+  str(group_id))['action'][parameter]
 
-    def set_group(self, group_id, parameter, value = None):
+    def set_group(self, group_id, parameter, value = None, transitiontime=None):
+        """ Set properties for a group of lamps. 
+        Same arguments and meaning as the set_light function, except that
+        of course you provide a group_id instead of a light_id as the first argument
+        """
+
         if type(parameter) == dict:
             data = parameter
         elif parameter == 'lights' and type(value) == list:
             data = {parameter : [str(x) for x in value] }
         else:
             data = {parameter : value}
+
+        if transitiontime is not None:
+            data['transitiontime'] = int(round(transitiontime)) # must be int for request format
 
         if parameter == 'name' or parameter == 'lights':
             return self.request('PUT', '/api/' + self.username + '/groups/'+ str(group_id), json.dumps(data))


### PR DESCRIPTION
The LightGroup class implements an identical interface as Light (in fact
it is a subclass derived from Light) but it works with the light group
API to control multiple lights at once.

There is also an AllLights class that enables control of all lights at
once. This makes use of the undocumented (even in the official API!)
feature that "group 0" is all lights connected to the bridge.
