### PR TITLE
pip packaging

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -37,6 +37,8 @@ if platform.system() == 'Windows':
 else:
     USER_HOME = 'HOME'
 
+__version__ = '0.1'
+
 
 class PhueException(Exception):
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup
+from phue import __version__
+
+readme = open('README.md').read()
+
+setup(name='phue',
+      version=__version__,
+      author='Nathanaël Lécaudé',
+      url='https://github.com/studioimaginaire/phue',
+      license='WTFPL',
+      description='A Philips Hue Python library',
+      long_description=readme,
+      py_modules=['phue'],
+      )


### PR DESCRIPTION
Not sure how you want to do the version numbering, so I just set it at 0.1 for now. I saw you had some tags but didn't look like they were still being used. Should definitely submit this to PyPi (https://pypi.python.org/pypi) so users can install from there.  

Can test install by running 
`pip install git+git://github.com/jlintz/phue.git@pip_package#egg=phue`
