### PR TITLE
Moved Logging configuration from module header to __main__ run

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -30,7 +30,7 @@ else:
 
 import logging
 logger = logging.getLogger('phue')
-logging.basicConfig(level=logging.INFO)
+
 
 if platform.system() == 'Windows':
     USER_HOME = 'USERPROFILE'
@@ -818,6 +818,8 @@ class Bridge(object):
 
 if __name__ == '__main__':
     import argparse
+
+    logging.basicConfig(level=logging.INFO)
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--host', required=True)


### PR DESCRIPTION
Having the logging configuration in the main module overwrites the logging configuration of any application using Phue as a module.

I moved the logging configuration to the **main** runtime to maintain its use, but will not affect any other logging statements.
