### PR TITLE
try to guess the ip if it's not given

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -413,6 +413,8 @@ class Bridge(object):
         else:
             self.config_file_path = os.path.join(os.getcwd(), '.python_hue')
 
+        if not ip:
+            ip = self.get_ip_address()  
         self.ip = ip
         self.username = username
         self.lights_by_id = {}


### PR DESCRIPTION
This pull request will let you use the examples without first having to figure out your ip, 
This will probably not work if you're not connected to the wide internet, but it's a very easy fix for now.

You could also imlement the upnp process yourself in the future to make this a bit more sturdy (e.g. as done here https://github.com/allanbunch/beautifulhue/pull/2/files#diff-bc9a9a6290c43731b439f5a4fdcc357bR75 )
