### PR TITLE
USER_HOME might return None

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -407,7 +407,7 @@ class Bridge(object):
 
         """
 
-        if os.access(os.getenv(USER_HOME), os.W_OK):
+        if os.getenv(USER_HOME) is not None and os.access(os.getenv(USER_HOME), os.W_OK):
             self.config_file_path = os.path.join(
                 os.getenv(USER_HOME), '.python_hue')
         else:


### PR DESCRIPTION
The USER_HOME variable is not always set, but os.access() requires a non-None value.
