### PR TITLE
b.lights gives KeyError 1 when removing light {1}

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -599,7 +599,7 @@ class Bridge(object):
         if mode == 'name':
             return self.lights_by_name
         if mode == 'list':
-            return [self.lights_by_id[x] for x in range(1, len(self.lights_by_id) + 1)]
+            return self.lights_by_id.values()
 
     def __getitem__(self, key):
         """ Lights are accessibly by indexing the bridge either with


### PR DESCRIPTION
I had a broken light, which was light number 1, after replacing this light with a new light, my python script based on phue no longer works, the new light has number 5. 
This results in a KeyError.
File "/usr/local/lib/python2.7/dist-packages/phue.py", line 588, in get_light_objects
return [self.lights_by_id[x] for x in range(1, len(self.lights_by_id) + 1)]
KeyError: 1

Thanks @BillX86 for this fix.