### PR TITLE
Fix scheduling parameter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ b.delete_group(1)
 
 ###Schedules
 
-You can view, create and delete schedules using the following methods.  Note that the time of the bridge is in UTC so you will need to offset with your timezone.
+You can view, create and delete schedules using the following methods. Note that updates to the Hue API now use local time instead of UTC. If you have issues with schedules not triggering correctly, double check that the time zone is set correctly on your Hue Bridge and that your time in your code is not in UTC by default.
 
 ```python
 

--- a/phue.py
+++ b/phue.py
@@ -1195,7 +1195,7 @@ class Bridge(object):
     def create_schedule(self, name, time, light_id, data, description=' '):
         schedule = {
             'name': name,
-            'time': time,
+            'localtime': time,
             'description': description,
             'command':
             {
@@ -1210,7 +1210,7 @@ class Bridge(object):
     def create_group_schedule(self, name, time, group_id, data, description=' '):
         schedule = {
             'name': name,
-            'time': time,
+            'localtime': time,
             'description': description,
             'command':
             {


### PR DESCRIPTION
Updates to the Hue API now use ```localtime``` instead of ```time``` as a schedule parameter. This also means that users need to be aware that any scripts they have will need to be modified to local time instead of UTC and that their time zone needs to be set correctly on their bridge.