### PR TITLE
Groups have scenes

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -527,6 +527,16 @@ class Group(Light):
             self.group_id, str(value)))
         self._set('lights', value)
 
+    # FIXME copy'd from light... shouldn't this work already since subclassing?
+    def __repr__(self):
+        # like default python repr function, but add sensor name
+        return '<{0}.{1} id="{2}" name="{3}" lights={4}>'.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.group_id,
+            self.name,
+            list((light.light_id for light in self.lights)))
+
 
 class AllLights(Group):
 

--- a/phue.py
+++ b/phue.py
@@ -537,6 +537,11 @@ class Group(Light):
             self.name,
             list((light.light_id for light in self.lights)))
 
+    @property
+    def scenes(self):
+        light_ids = sorted([x.light_id for x in self.lights])
+        return list(scene for scene in self.bridge.scenes if light_ids == scene.lights)
+
 
 class AllLights(Group):
 


### PR DESCRIPTION
This takes a hint from `Bridge#run_scene`, but lets groups discover the scenes that use the same lights on it.

My thought was to use this to extend homeassistant to be able to use groups & scenes powered by the Hue bridge. Just looking at scenes, it seems there's a lot of cruft on your average bridge that doesn't line up with what's in the Hue app, so it seems that looking for scenes matching a group is the best way to approach it.

cc @thundergreen @sdague