### PR TITLE
Fix #93

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -780,7 +780,7 @@ class Bridge(object):
             return self.lights_by_name
         if mode == 'list':
             # return ligts in sorted id order, dicts have no natural order
-            return [self.lights_by_id[id] for id in sorted(self.lights_by_id.keys())]
+            return [self.lights_by_id[id] for id in sorted(self.lights_by_id)]
 
     def get_sensor_id_by_name(self, name):
         """ Lookup a sensor id based on string name. Case-sensitive. """

--- a/phue.py
+++ b/phue.py
@@ -779,7 +779,8 @@ class Bridge(object):
         if mode == 'name':
             return self.lights_by_name
         if mode == 'list':
-            return self.lights_by_id.values()
+            # return ligts in sorted id order, dicts have no natural order
+            return [self.lights_by_id[id] for id in sorted(self.lights_by_id.keys())]
 
     def get_sensor_id_by_name(self, name):
         """ Lookup a sensor id based on string name. Case-sensitive. """


### PR DESCRIPTION
Use list comprehension to return `get_light_objects` in list mode in sorted id order as dicts have no natural order and calling `.values()` can return them in random order

Fixes #93