### PR TITLE
Add support for port parameter

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -595,7 +595,7 @@ class Bridge(object):
 
 
     """
-    def __init__(self, ip=None, username=None, config_file_path=None):
+    def __init__(self, ip=None, username=None, config_file_path=None, port=None):
         """ Initialization function.
 
         Parameters:
@@ -616,6 +616,7 @@ class Bridge(object):
             self.config_file_path = os.path.join(os.getcwd(), '.python_hue')
 
         self.ip = ip
+        self.port = port
         self.username = username
         self.lights_by_id = {}
         self.lights_by_name = {}
@@ -644,7 +645,7 @@ class Bridge(object):
 
     def request(self, mode='GET', address=None, data=None):
         """ Utility function for HTTP GET/PUT requests for the API"""
-        connection = httplib.HTTPConnection(self.ip, timeout=10)
+        connection = httplib.HTTPConnection(self.ip, self.port, timeout=10)
 
         try:
             if mode == 'GET' or mode == 'DELETE':


### PR DESCRIPTION
Hello guys,
thanks a lot for this great and useful project!
With this simple pull request, I'd like to add support for specifying a port parameter in the initializer of the Bridge.

_Background_: I have ZigBee hardware addon for the Raspberry Pi which is called RaspBee (https://www.dresden-elektronik.de/raspbee). The vendor provide a REST service that is compatible with Philips hue and that can run on an different port then the default 80. With the changes in this PR and some other changes in the "hue" component within the "Home Assistant" project (https://home-assistant.io), I am able to connect to that device and control the lights.