### PR TITLE
Close connection after read() in request()

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -661,14 +661,13 @@ class Bridge(object):
             raise PhueRequestTimeout(None, error)
 
         result = connection.getresponse()
-        connection.close()
         if PY3K:
             return json.loads(str(result.read(), encoding='utf-8'))
         else:
             result_str = result.read()
             logger.debug(result_str)
             return json.loads(result_str)
-
+        connection.close()
     def get_ip_address(self, set_result=False):
 
         """ Get the bridge ip address from the meethue.com nupnp api """


### PR DESCRIPTION
I use Home Assistant, and HA can't connect to my (admittedly not Hue, but Hue-compatible) lighting bridge unless I make this change.

I can try and come up with a minimal test case if necessary, but the exact error I get without this patch is:

```
ERROR:homeassistant.components.light:Error while setting up platform hue
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/homeassistant/helpers/entity_component.py", line 155, in _async_setup_platform
    entity_platform.schedule_add_entities, discovery_info
  File "/usr/lib/python3.4/asyncio/futures.py", line 388, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.4/asyncio/tasks.py", line 286, in _wakeup
    value = future.result()
  File "/usr/lib/python3.4/asyncio/futures.py", line 277, in result
    raise self._exception
  File "/usr/lib/python3.4/concurrent/futures/thread.py", line 54, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.4/dist-packages/homeassistant/components/light/hue.py", line 138, in setup_platform
    allow_in_emulated_hue, allow_hue_groups)
  File "/usr/local/lib/python3.4/dist-packages/homeassistant/components/light/hue.py", line 258, in setup_bridge
    update_lights()
  File "/usr/local/lib/python3.4/dist-packages/homeassistant/util/__init__.py", line 303, in wrapper
    result = method(*args, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/homeassistant/util/__init__.py", line 303, in wrapper
    result = method(*args, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/homeassistant/components/light/hue.py", line 182, in update_lights
    api = bridge.get_api()
  File "/home/pi/.homeassistant/deps/phue.py", line 838, in get_api
    return self.request('GET', '/api/' + self.username)
  File "/home/pi/.homeassistant/deps/phue.py", line 666, in request
    return json.loads(str(result.read(), encoding='utf-8'))
  File "/usr/lib/python3.4/json/__init__.py", line 318, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.4/json/decoder.py", line 343, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.4/json/decoder.py", line 361, in raw_decode
    raise ValueError(errmsg("Expecting value", s, err.value)) from None
ValueError: Expecting value: line 1 column 1 (char 0)
```