### PR TITLE
Implement function for setting schedule attributes

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -1208,6 +1208,13 @@ class Bridge(object):
         }
         return self.request('POST', '/api/' + self.username + '/schedules', schedule)
 
+    def set_schedule_attributes(self, schedule_id, attributes):
+        """
+        :param schedule_id: 
+        :param attributes: dictionary with attributes and their new values
+        """
+        return self.request('PUT', '/api/' + self.username + '/schedules/' + str(schedule_id), data=attributes)
+
     def create_group_schedule(self, name, time, group_id, data, description=' '):
         schedule = {
             'name': name,

--- a/phue.py
+++ b/phue.py
@@ -1210,8 +1210,8 @@ class Bridge(object):
 
     def set_schedule_attributes(self, schedule_id, attributes):
         """
-        :param schedule_id: 
-        :param attributes: dictionary with attributes and their new values
+        :param schedule_id: The ID of the schedule
+        :param attributes: Dictionary with attributes and their new values
         """
         return self.request('PUT', '/api/' + self.username + '/schedules/' + str(schedule_id), data=attributes)
 


### PR DESCRIPTION
This adds a public method to allow the user to update attributes of the given schedule. It’s based on this section of the official documentation: https://developers.meethue.com/documentation/schedules-api-0#34_set_schedule_attributes