### PR TITLE
Remove formatting error in README's title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-˜# phue: A Python library for Philips Hue
+# phue: A Python library for Philips Hue
 
 Full featured Python library to control the Philips Hue lighting system.
 


### PR DESCRIPTION
Now the title actually *renders* as a title.