### PR TITLE
Added the ability to use the remote API

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ You can read more about the token and authentication at https://developers.meeth
 #### Interacting with the token
 You shouldn't need to interact with the token as the code refresh process is handled automatically. But if you feel like you want to, or have the need to inspect it closer, then the token is just an attribute of the `RemoteBridge` object (aptly named `token`).
 ```python
+>>> from phue import RemoteBridge
+>>> b = RemoteBridge()
 >>> b.token
 <phue.RemoteToken object at 0x102caedd0>
 ```
@@ -325,7 +327,7 @@ False
 >>> b.token.access_expires
 'Sun Apr 22 10:35:35 2018'
 
-# When does the refresh token expire?
+# When does the Refresh token expire?
 >>> b.token.refresh_expires
 'Sun Aug  5 10:35:35 2018'
 
@@ -353,8 +355,8 @@ u'ghcgX4uJ3FMdGpBUD7cBGNQV4hVK'
 >>> b.token.refresh_token
 u'WMsPGsx5FsvUwEpjwz94noxdJ7mtxgNK'
 
-# Save to a new or different token file.
-b.token.save()
+# Save to a new or different token file, invalidating the old token file.
+b.token.save('/path/to/new/location.token')
 ```
 
 ## Using phue with Max/MSP via Jython

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-handledautomatically# phue: A Python library for Philips Hue
+# phue: A Python library for Philips Hue
 
 Full featured Python library to control the Philips Hue lighting system.
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ u'ghcgX4uJ3FMdGpBUD7cBGNQV4hVK'
 u'WMsPGsx5FsvUwEpjwz94noxdJ7mtxgNK'
 
 # Save to a new or different token file, invalidating the old token file.
-b.token.save('/path/to/new/location.token')
+>>> b.token.save('/path/to/new/location.token')
 ```
 
 ## Using phue with Max/MSP via Jython

--- a/phue.py
+++ b/phue.py
@@ -672,7 +672,7 @@ class Bridge(object):
 
     def request(self, mode='GET', address=None, data=None):
         """ Utility function for HTTP GET/PUT requests for the API"""
-        if self.token:
+        if hasattr(self, 'token'):
             connection = httplib.HTTPSConnection(self.ip, timeout=20)
             headers = {
                 'Content-Type': 'application/json',

--- a/phue.py
+++ b/phue.py
@@ -1408,7 +1408,6 @@ class RemoteToken(object):
             webbrowser.open(URL)
         except:
             logger.info('The was an error opening the web browser')
-            pass
         print('Your web browser should open a Philips Hue page asking you to provide authorisation to access your Philips Hue system.\nNote that you need to sign in with your Philips Hue account, not your developer account.\nIf your browser doesn\'t open, you can manually visit the following address:\n' + URL + '\nOnce you have provided authorisation, you will be redirected to the callback URL that you specified when setting up your developer credentials.\nPlease enter the entire address of the page you are sent to after completing authorisation:')
         resp = input('Address: ')
         parsed = urlparse(resp)
@@ -1559,7 +1558,6 @@ class RemoteToken(object):
             return False
         else:
             return True
-        pass
 
     @property
     def valid(self):
@@ -1572,7 +1570,6 @@ class RemoteToken(object):
             return True
         else:
             return False
-        pass
 
     def save(self, saveto=None):
         """ Save the token data so it can be loaded later.

--- a/phue.py
+++ b/phue.py
@@ -36,6 +36,7 @@ if PY3K:
     import http.client as httplib
     from datetime import timezone
     from urllib.parse import parse_qs, urlparse, urlencode
+
     UTC = timezone.utc
 else:
     import httplib
@@ -43,19 +44,17 @@ else:
     from urllib import urlencode
     from urlparse import parse_qs, urlparse
 
-    FileNotFoundError = IOError
-
     class UTC(tzinfo):
         def utcoffset(self, dt):
             return timedelta(0)
-
         def tzname(self, dt):
             return "UTC"
-
         def dst(self, dt):
             return timedelta(0)
-    UTC = UTC()
+
+    FileNotFoundError = IOError
     input = raw_input
+    UTC = UTC()
 
 logger = logging.getLogger('phue')
 
@@ -1374,7 +1373,7 @@ class RemoteToken(object):
             saveto (str optional): The file to save details to so they can be
                 reloaded at a later time.
             load (str optional): If specified, load token data from the path
-                instead of attempting to autorise a new one. This will override
+                instead of attempting to authorise a new one. This will override
                 the remaining attributes, as they are filled from the file
                 contents instead.
         """
@@ -1386,11 +1385,11 @@ class RemoteToken(object):
             self.clientsecret = clientsecret
             self.appid = appid
             self.saveto = saveto
-            self.__authorize__()
+            self.__authorise__()
         else:
             raise ValueError('Missing required argumets clientid, clientsecret and appid')
 
-    def __authorize__(self):
+    def __authorise__(self):
         """ Obtains new access and refresh tokens from the Philips Hue API
 
         This method is intended to be called from the `__init__` method.


### PR DESCRIPTION
This pull request adds the ability to use the Hue API remotely. I've kept in mind some of the goals of this project (single file, 2 and 3 compatibility and no module dependencies). The README is updated to include documentation on the remote API.

A user will be required to provide their own credentials from the Philips Hue developer's portal.

Some small changes were required to the existing `Bridge` class to enable a new `RemoteBridge` to subclass it. The main change was changing the base of the API URL from a string literal `/api/` to an instance variable, since the URL base is `/bridge/` for the remote API. The other was the ability to add authentication headers to the `request()` method.

Another change was required to facilitate simple authorisation and token generation from a terminal.

The rest of the new code is creating a `Token` class to handle the authentication tokens, and a `RemoteBridge` subclass of the `Bridge` class.