### PR TITLE
fix return type in get_group_id_by_name This PR simply addresses an issue in the return type of `get_group_id_by_name`.

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -1053,10 +1053,10 @@ class Bridge(object):
         for group_id in groups:
             if PY3K:
                 if name == groups[group_id]['name']:
-                    return group_id
+                    return int(group_id)
             else:
                 if name.decode('utf-8') == groups[group_id]['name']:
-                    return group_id
+                    return int(group_id)
         return False
 
     def get_group(self, group_id=None, parameter=None):


### PR DESCRIPTION
In it's current form, it is impossible to use `get_group_id_by_name` with `get_group` because the return type of `get_group_id_by_name` is a string, whereas `get_group` expects and int. This fixes that.

Let me know if you have any questions.