### PR TITLE
Add scene properties 'type' and 'group'

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -549,7 +549,8 @@ class Scene(object):
 
     def __init__(self, sid, appdata=None, lastupdated=None,
                  lights=None, locked=False, name="", owner="",
-                 picture="", recycle=False, version=0):
+                 picture="", recycle=False, version=0, type="", group=0,
+                 *args, **kwargs):
         self.scene_id = sid
         self.appdata = appdata or {}
         self.lastupdated = lastupdated
@@ -563,6 +564,8 @@ class Scene(object):
         self.picture = picture
         self.recycle = recycle
         self.version = version
+        self.type = type
+        self.group = group
 
     def __repr__(self):
         # like default python repr function, but add sensor name

--- a/phue.py
+++ b/phue.py
@@ -549,7 +549,7 @@ class Scene(object):
 
     def __init__(self, sid, appdata=None, lastupdated=None,
                  lights=None, locked=False, name="", owner="",
-                 picture="", recycle=False, version=0, type="", group=0,
+                 picture="", recycle=False, version=0, type="", group="",
                  *args, **kwargs):
         self.scene_id = sid
         self.appdata = appdata or {}


### PR DESCRIPTION
Noticed tonight that the `Bridge.load_scene` function was working, complaining with the error message:
```
Traceback (most recent call last):
  File "/Users/noah/code/viki/app/hue/hue.py", line 35, in <module>
    h.load_scene('Relax')
  File "/Users/noah/code/viki/app/hue/hue.py", line 17, in load_scene
    self.bridge.run_scene('Noah Bedroom', scene_name)
  File "/Users/noah/code/viki/venv/lib/python3.7/site-packages/phue.py", line 1166, in run_scene
    scenes = [x for x in self.scenes if x.name == scene_name]
  File "/Users/noah/code/viki/venv/lib/python3.7/site-packages/phue.py", line 1138, in scenes
    return [Scene(k, **v) for k, v in self.get_scene().items()]
  File "/Users/noah/code/viki/venv/lib/python3.7/site-packages/phue.py", line 1138, in <listcomp>
    return [Scene(k, **v) for k, v in self.get_scene().items()]
TypeError: __init__() got an unexpected keyword argument 'type'
```
When I tested on the Hue API debugging tool at `/api/<username>/scenes`, I got responses such as
```
{
	"KL2XQKROiKfvwQU": {
		"name": "Savanna sunset",
		"type": "GroupScene",
		"group": "1",
		"lights": [
			"1",
			"2"
		],
		"owner": "Z6JmooCHGmbrg65weMUH5dPnTPtP1ryQ5kTwnS2x",
		"recycle": false,
		"locked": false,
		"appdata": {
			"version": 1,
			"data": "XqVVT_r01_d15"
		},
		"picture": "",
		"lastupdated": "2018-09-07T02:28:38",
		"version": 2
	},
        ...
}
```
The `type` and `group` properties must have been causing the error. My fix just adds the two new properties, and adds `*args` and `*kwargs` to catch any future unexpected property additions.

Passes unit tests, though there didn't seem to be any tests that specifically tested this function.

Tested manually with the following software versions:
Bridge: Version 1810251352
Lights: Version 1.29.0_r21169