### PR TITLE
Reverted `e5e550bf` `decodeString` in Bridge.request

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -662,8 +662,11 @@ class Bridge(object):
         result = connection.getresponse()
         response = result.read()
         connection.close()
+        if PY3K:
+            response = response.decode('utf-8')
+
         logger.debug(response)
-        return json.loads(decodeString(response))
+        return json.loads(response)
 
     def get_ip_address(self, set_result=False):
 


### PR DESCRIPTION
In Python 3 `httplib.HTTPConnection.getresponse().read()` returns a
bytes stream, not a string. Therefore commit `e5e550bf` broke the
request parsing on Python 3:

```
>>> from phue import Bridge
>>> b = Bridge('hue')
>>> b.get_scene()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/blacklight/git_tree/phue/phue.py", line 1128, in get_scene
    return self.request('GET', '/api/' + self.username + '/scenes')
  File "/home/blacklight/git_tree/phue/phue.py", line 666, in request
    return json.loads(decodeString(response))
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```