### PR TITLE
Fixed Python 3.9 compatibility

### DIFF
--- a/phue.py
+++ b/phue.py
@@ -691,7 +691,7 @@ class Bridge(object):
 
         ip = str(data[0]['internalipaddress'])
 
-        if ip is not '':
+        if ip:
             if set_result:
                 self.ip = ip
 


### PR DESCRIPTION
The usage of the is/is not operators with any values other than `True`/`False`/`None` has been deprecated and removed in Python 3.9.

This causes the following error when running the library on the latest Python interpreter:

```
/usr/lib/python3.9/site-packages/phue.py:694: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if ip is not '':
```